### PR TITLE
Reverted cmake version. Still need bionic for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
 matrix:
   include:
     - os: linux
-      dist: focal
+      dist: bionic
       compiler: gcc
       arch: amd64
       addons:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 ### Top Level CMake Script for C++ Units ###
-cmake_minimum_required(VERSION 3.15.0)
+cmake_minimum_required(VERSION 3.12.0)
 project(CppUnits VERSION 1.0.0)
 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The C++ Units project was designed to have as few external dependencies as possi
 
 ### Build Requirements
 
-- [CMake](https://cmake.org): Version 3.15.0 or higher. See the documentation in the [`BUILD.md`](docs/BUILD.md) file for specific instructions on installing the project.
+- [CMake](https://cmake.org): Version 3.12.0 or higher. See the documentation in the [`BUILD.md`](docs/BUILD.md) file for specific instructions on installing the project.
 
 ### Test Requirements
 

--- a/cmake/CMakeLists.txt.in
+++ b/cmake/CMakeLists.txt.in
@@ -1,5 +1,5 @@
 ### Download Instructions for External Projects ###
-cmake_minimum_required(VERSION 3.15.0)
+cmake_minimum_required(VERSION 3.12.0)
 
 project(${EXTERN_ARGS_PROJECT}-download NONE)
 


### PR DESCRIPTION
# Pull Request Template for C++ Units

Fixing bug with CMake version. Bionic distribution requires 3.12 and that's the version that works with our code coverage analysis.
